### PR TITLE
add HAPI ingress overrides file

### DIFF
--- a/dev/docker-compose.ingress.yaml
+++ b/dev/docker-compose.ingress.yaml
@@ -1,0 +1,19 @@
+---
+version: "3.4"
+services:
+  fhir:
+    # expose HAPI to internet
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.fhir-${COMPOSE_PROJECT_NAME}.rule=Host(`fhir.${BASE_DOMAIN:-localtest.me}`)"
+      - "traefik.http.routers.fhir-${COMPOSE_PROJECT_NAME}.entrypoints=websecure"
+      - "traefik.http.routers.fhir-${COMPOSE_PROJECT_NAME}.tls=true"
+      - "traefik.http.routers.fhir-${COMPOSE_PROJECT_NAME}.tls.certresolver=letsencrypt"
+    networks:
+      - ingress
+
+networks:
+  # ingress network
+  ingress:
+    external: true
+    name: external_web

--- a/dev/docker-compose.ingress.yaml
+++ b/dev/docker-compose.ingress.yaml
@@ -12,8 +12,3 @@ services:
     networks:
       - ingress
 
-networks:
-  # ingress network
-  ingress:
-    external: true
-    name: external_web


### PR DESCRIPTION
Repo was missing boiler plate for overrides used to expose HAPI in specially configured dev repos.