### PR TITLE
DockerHub Migration

### DIFF
--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -47,7 +47,7 @@ services:
 
 
   femr:
-    image: uwcirg/cosri-patientsearch:${FEMR_IMAGE_TAG:-develop}
+    image: ghcr.io/uwcirg/cosri-patientsearch:${FEMR_IMAGE_TAG:-latest}
     env_file:
       femr.env
     environment:

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -47,7 +47,7 @@ services:
 
 
   femr:
-    image: ghcr.io/uwcirg/cosri-patientsearch:${FEMR_IMAGE_TAG:-latest}
+    image: ghcr.io/uwcirg/cosri-patientsearch:${FEMR_IMAGE_TAG:-develop}
     env_file:
       femr.env
     environment:

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -141,7 +141,7 @@ services:
 
 
   keycloak:
-    image: jboss/keycloak:${KEYCLOAK_IMAGE_TAG:-15.0.2}
+    image: quay.io/keycloak/keycloak:${KEYCLOAK_IMAGE_TAG:-15.0.2}
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.keycloak-${COMPOSE_PROJECT_NAME}.rule=Host(`keycloak.${BASE_DOMAIN:-localtest.me}`)"


### PR DESCRIPTION
- Migrate existing repos away from DockerHub ([new API rate-limiting](https://www.docker.com/blog/what-you-need-to-know-about-upcoming-docker-hub-rate-limiting/))
  - Switch to GHCR for github repos
  - Switch to quay.io (Redhat support image registry) for Keycloak