### PR TITLE
log jwt-proxy mutations

### DIFF
--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -60,7 +60,7 @@ services:
       OIDC_TOKEN_URI: "https://keycloak.${BASE_DOMAIN:-localtest.me}/auth/realms/fEMR/protocol/openid-connect/token"
       OIDC_TOKEN_INTROSPECTION_URI: "https://keycloak.${BASE_DOMAIN:-localtest.me}/auth/realms/fEMR/protocol/openid-connect/token/introspect"
       # TODO change to INTERNAL_FHIR_API
-      MAP_API: 'https://fhirwall.${BASE_DOMAIN:-localtest.me}/fhir'
+      MAP_API: 'https://fhirwall.${BASE_DOMAIN:-localtest.me}/fhir/'
       # FHIR URL passed to SoF client
       SOF_HOST_FHIR_URL: 'https://fhirwall.${BASE_DOMAIN:-localtest.me}/fhir'
       SOF_CLIENTS: '[{"id":"SCREENER", "label":"New Assessment", "launch_url":"https://confidentialbackend.${BASE_DOMAIN:-localtest.me}/auth/launch", "required_roles": ["clinician"]}, {"id":"SUMMARY", "label":"View Report", "launch_url":"https://summary.${BASE_DOMAIN:-localtest.me}/launch.html", "required_roles": ["clinician"]}]'

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -112,6 +112,7 @@ services:
     env_file:
       fhirwall.env
     environment:
+      LOGSERVER_URL: "https://logs.${BASE_DOMAIN:-localtest.me}"
       OIDC_AUTHORIZE_URL: "https://keycloak.${BASE_DOMAIN:-localtest.me}/auth/realms/fEMR/protocol/openid-connect/auth"
       OIDC_TOKEN_URI: "https://keycloak.${BASE_DOMAIN:-localtest.me}/auth/realms/fEMR/protocol/openid-connect/token"
       OIDC_TOKEN_INTROSPECTION_URI: "https://keycloak.${BASE_DOMAIN:-localtest.me}/auth/realms/fEMR/protocol/openid-connect/token/introspect"
@@ -134,6 +135,7 @@ services:
       - "traefik.http.routers.fhirwall-${COMPOSE_PROJECT_NAME}.tls.certresolver=letsencrypt"
     depends_on:
       - fhir
+      - logs
     networks:
       - ingress
       - internal

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -60,8 +60,7 @@ services:
       OIDC_TOKEN_URI: "https://keycloak.${BASE_DOMAIN:-localtest.me}/auth/realms/fEMR/protocol/openid-connect/token"
       OIDC_TOKEN_INTROSPECTION_URI: "https://keycloak.${BASE_DOMAIN:-localtest.me}/auth/realms/fEMR/protocol/openid-connect/token/introspect"
       # TODO change to INTERNAL_FHIR_API
-      # TODO switch to external API (requiring auth)
-      MAP_API: "http://fhir-internal:8080/fhir/"
+      MAP_API: 'https://fhirwall.${BASE_DOMAIN:-localtest.me}/fhir'
       # FHIR URL passed to SoF client
       SOF_HOST_FHIR_URL: 'https://fhirwall.${BASE_DOMAIN:-localtest.me}/fhir'
       SOF_CLIENTS: '[{"id":"SCREENER", "label":"New Assessment", "launch_url":"https://confidentialbackend.${BASE_DOMAIN:-localtest.me}/auth/launch", "required_roles": ["clinician"]}, {"id":"SUMMARY", "label":"View Report", "launch_url":"https://summary.${BASE_DOMAIN:-localtest.me}/launch.html", "required_roles": ["clinician"]}]'

--- a/dev/fhirwall.env.default
+++ b/dev/fhirwall.env.default
@@ -5,4 +5,7 @@
 # Variables defined in this file will only be available to containers/images
 # ie not for interpolation in docker-compose YAML files
 
+# JWT with embeded secret to match PGRST_JWT_SECRET from logs.env
+LOGSERVER_TOKEN=
+
 SECRET_KEY=


### PR DESCRIPTION
configuration changes needed to incorporate logserver in jwt-proxy to capture FHIR mutations as part of https://github.com/uwcirg/jwt-proxy/pull/6

(dcw-environments version of identical work in https://github.com/uwcirg/helloworld-environments/pull/4 )